### PR TITLE
Override getFullIdentifier method in HivePartitionTap to use the full identifier from the parent.

### DIFF
--- a/src/main/java/cascading/tap/hive/HivePartitionTap.java
+++ b/src/main/java/cascading/tap/hive/HivePartitionTap.java
@@ -100,4 +100,10 @@ public class HivePartitionTap extends PartitionTap
     return new HivePartitionCollector( flowProcess );
     }
 
+  @Override
+  public String getFullIdentifier(JobConf conf)
+    {
+    return parent.getFullIdentifier(conf);
+    }
+
   }

--- a/version.properties
+++ b/version.properties
@@ -18,4 +18,4 @@
 # limitations under the License.
 #
 cascading.hive.release.major=1.0
-cascading.hive.release.minor=0
+cascading.hive.release.minor=1


### PR DESCRIPTION
The hive partition tap does not get a full identifier with the qualified path which can cause it to have a different path for the source than the sink who is writing the data to disk and break cascade scheduling.

The `getFullIdentifier` method needs to be overwritten to use the full identifier from the parent tap.
