### PR TITLE
Multiple queries support

### DIFF
--- a/demo/src/main/java/cascading/hive/HiveDemo.java
+++ b/demo/src/main/java/cascading/hive/HiveDemo.java
@@ -84,9 +84,13 @@ public class HiveDemo
     HiveTap keyvalueTap = new HiveTap( keyValueDescriptor, keyValueDescriptor.toScheme(), SinkMode.REPLACE, true );
 
     // populate data in keyvalue by selecting data from dual
+    // truncate keyvalue afterwards as an example of multiple queries. 
+    String queries[] = {
+        "insert overwrite table keyvalue select 'Hello' as key, 'hive!' as value from dual",
+        "truncate keyvalue"
+    };
     HiveFlow selectFlow = new HiveFlow( "select data from dual into keyvalue",
-      "insert overwrite table keyvalue select 'Hello' as key, 'hive!' as value from dual ",
-      Arrays.<Tap>asList( dualTap ), keyvalueTap );
+      queries, Arrays.<Tap>asList( dualTap ), keyvalueTap );
 
     // describe a third table, similar to keyvalue. This will be used as a sink in a pure cascading flow
     HiveTableDescriptor keyValueDescriptor2 = new HiveTableDescriptor( "keyvalue2", new String[]{"key", "value"},

--- a/src/main/java/cascading/flow/hive/HiveFlow.java
+++ b/src/main/java/cascading/flow/hive/HiveFlow.java
@@ -33,41 +33,74 @@ import cascading.tap.hive.HiveNullTap;
  */
 public class HiveFlow extends ProcessFlow
   {
-
   /**
-   * Constructs a new HiveFlow object with the given name, query, a list of source taps and sink.
+   * Constructs a new HiveFlow object with the given name, queries, a list of source taps and sink.
    *
    * @param name    The name of the flow.
-   * @param query   The hive query to run.
-   * @param sources The source taps of the query.
-   * @param sink    The sink of the query.
+   * @param queries The hive queries to run, separated by `;`.
+   * @param sources The source taps of the queries.
+   * @param sink    The sink of the queries.
    */
   public HiveFlow( String name, String query, Collection<cascading.tap.Tap> sources, Tap sink )
     {
-    this( name, new HiveDriverFactory(), query, sources, sink );
+    this( name, new HiveDriverFactory(), new String[]{query}, sources, sink );
     }
 
 
   /**
-   * Constructs a new HiveFlow object with the given name, query, a list of source taps. This constructor can be
+   * Constructs a new HiveFlow object with the given name, queries, a list of source taps. This constructor can be
    * used when the Flow does not really have
    *
    * @param name    The name of the flow.
-   * @param query   The hive query to run.
-   * @param sources The source taps of the query.
+   * @param queries The hive queries to run.
+   * @param sources The source taps of the queries.
    */
   public HiveFlow( String name, String query, Collection<Tap> sources )
     {
-    this( name, new HiveDriverFactory(), query, sources, HiveNullTap.DEV_NULL );
+    this( name, new HiveDriverFactory(), new String[]{query}, sources, HiveNullTap.DEV_NULL );
     }
 
+  /**
+   * Constructs a new HiveFlow object with the given name, queries, a list of source taps and sink.
+   *
+   * @param name    The name of the flow.
+   * @param queries The hive queries to run, separated by `;`.
+   * @param sources The source taps of the queries.
+   * @param sink    The sink of the queries.
+   */
+  public HiveFlow( String name, String queries[], Collection<cascading.tap.Tap> sources, Tap sink )
+    {
+    this( name, new HiveDriverFactory(), queries, sources, sink );
+    }
+
+
+  /**
+   * Constructs a new HiveFlow object with the given name, queries, a list of source taps. This constructor can be
+   * used when the Flow does not really have
+   *
+   * @param name    The name of the flow.
+   * @param queries The hive queries to run.
+   * @param sources The source taps of the queries.
+   */
+  public HiveFlow( String name, String queries[], Collection<Tap> sources )
+    {
+    this( name, new HiveDriverFactory(), queries, sources, HiveNullTap.DEV_NULL );
+    }
 
   /**
    * Package private constructor which allows injecting a custom HiveDriverFactory during tests.
    */
   HiveFlow( String name, HiveDriverFactory driverFactory, String query, Collection<cascading.tap.Tap> sources, Tap sink )
     {
-    super( name, new HiveRiffle( driverFactory, query, sources, sink ) );
+    super( name, new HiveRiffle( driverFactory, new String[]{query}, sources, sink ) );
+    }
+
+  /**
+   * Package private constructor which allows injecting a custom HiveDriverFactory during tests.
+   */
+  HiveFlow( String name, HiveDriverFactory driverFactory, String queries[], Collection<cascading.tap.Tap> sources, Tap sink )
+    {
+    super( name, new HiveRiffle( driverFactory, queries, sources, sink ) );
     }
 
 

--- a/src/main/java/cascading/flow/hive/HiveRiffle.java
+++ b/src/main/java/cascading/flow/hive/HiveRiffle.java
@@ -50,22 +50,22 @@ public class HiveRiffle
   /** a hive driver factory */
   private final HiveDriverFactory driverFactory;
 
-  /** The hive query to run */
-  private String query;
+  /** The hive queries to run */
+  private String queries[];
 
   /**
-   * Constructs a new HiveRiffle with the given HiveConf object, query, a list of source taps and a sink.
+   * Constructs a new HiveRiffle with the given HiveConf object, queries, a list of source taps and a sink.
    *
    * @param driverFactory a factory for creating Driver instances.
-   * @param query    The hive query to run.
-   * @param sources The source taps of the query.
-   * @param sink  The sink of the query.
+   * @param queries    The hive queries to run.
+   * @param sources The source taps of the queries.
+   * @param sink  The sink of the queries.
    */
-  @ConstructorProperties({"hiveConf", "query", "sources", "sink"})
-  HiveRiffle( HiveDriverFactory driverFactory, String query, Collection<Tap> sources, Tap sink )
+  @ConstructorProperties({"hiveConf", "queries", "sources", "sink"})
+  HiveRiffle( HiveDriverFactory driverFactory, String queries[], Collection<Tap> sources, Tap sink )
     {
     this.driverFactory = driverFactory;
-    this.query = query;
+    this.queries = queries;
     if ( sources == null || sources.isEmpty() )
       throw new CascadingException( "sources cannot be null or empty" );
     this.sources = sources;
@@ -93,7 +93,7 @@ public class HiveRiffle
   @ProcessComplete
   public void complete()
     {
-    HiveQueryRunner runner = new HiveQueryRunner( driverFactory, query );
+    HiveQueryRunner runner = new HiveQueryRunner( driverFactory, queries );
     runner.run();
     }
 

--- a/src/test/java/cascading/HiveTestCase.java
+++ b/src/test/java/cascading/HiveTestCase.java
@@ -83,7 +83,7 @@ public class HiveTestCase extends PlatformTestCase
    */
   public void runHiveQuery( String query )
     {
-    HiveQueryRunner runner = new HiveQueryRunnerForTesting( hiveDriverFactory, query );
+    HiveQueryRunner runner = new HiveQueryRunnerForTesting( hiveDriverFactory, new String[]{query} );
     runner.run();
     }
 

--- a/src/test/java/cascading/flow/hive/HiveFlowTest.java
+++ b/src/test/java/cascading/flow/hive/HiveFlowTest.java
@@ -41,7 +41,27 @@ public class HiveFlowTest extends HiveTestCase
     {
     Tap sink = new Hfs( new NullScheme(), "/foo" );
     List<Tap> sources = Arrays.asList( (Tap) new Hfs( new NullScheme(), "/bar" ) );
-    HiveFlow flow = new HiveFlow( "some name", createHiveDriverFactory(), "select * from foo", sources, sink );
+    HiveFlow flow = new HiveFlow( "some name", createHiveDriverFactory(),
+                                  "select * from foo", sources, sink );
+    assertEquals( sink, flow.getSink() );
+    Map<String, Tap> expectedSources = new HashMap<String, Tap>(  );
+    expectedSources.put( "/bar", sources.get( 0 ) );
+    assertEquals( expectedSources, flow.getSources() );
+    assertEquals( "some name", flow.getName() );
+    }
+
+  @Test
+  public void testConstructionMultiple()
+    {
+    String queries[] = {
+        "select * from foo",
+        "select count(*) from foo"
+    };
+
+    Tap sink = new Hfs( new NullScheme(), "/foo" );
+    List<Tap> sources = Arrays.asList( (Tap) new Hfs( new NullScheme(), "/bar" ) );
+    HiveFlow flow = new HiveFlow( "some name", createHiveDriverFactory(),
+                                  queries, sources, sink );
     assertEquals( sink, flow.getSink() );
     Map<String, Tap> expectedSources = new HashMap<String, Tap>(  );
     expectedSources.put( "/bar", sources.get( 0 ) );

--- a/src/test/java/cascading/flow/hive/HiveQueryRunnerForTesting.java
+++ b/src/test/java/cascading/flow/hive/HiveQueryRunnerForTesting.java
@@ -22,8 +22,8 @@ package cascading.flow.hive;
 
 public class HiveQueryRunnerForTesting extends HiveQueryRunner
   {
-  public HiveQueryRunnerForTesting( HiveDriverFactory driverFactory, String query )
+  public HiveQueryRunnerForTesting( HiveDriverFactory driverFactory, String queries[] )
     {
-    super(driverFactory, query );
+    super(driverFactory, queries );
     }
   }

--- a/src/test/java/cascading/flow/hive/HiveRiffleTest.java
+++ b/src/test/java/cascading/flow/hive/HiveRiffleTest.java
@@ -53,7 +53,7 @@ public class HiveRiffleTest extends HiveTestCase
     {
     Tap mockSource = Mockito.mock( Tap.class );
     Tap mockSink = Mockito.mock( Tap.class );
-    HiveRiffle riffle = new HiveRiffle( createHiveDriverFactory(), "creat table foo (key string)",
+    HiveRiffle riffle = new HiveRiffle( createHiveDriverFactory(), new String[]{"creat table foo (key string)"},
       Arrays.asList( mockSource ), mockSink );
     riffle.complete();
     }
@@ -62,7 +62,7 @@ public class HiveRiffleTest extends HiveTestCase
   public void testEmptySources()
     {
     Tap mockSink = Mockito.mock( Tap.class );
-    new HiveRiffle( createHiveDriverFactory(), "create table foo (key string)",
+    new HiveRiffle( createHiveDriverFactory(), new String[]{"create table foo (key string)"},
       new ArrayList<Tap>(  ), mockSink );
     }
 
@@ -70,7 +70,7 @@ public class HiveRiffleTest extends HiveTestCase
   public void testNullSources()
     {
     Tap mockSink = Mockito.mock( Tap.class );
-    new HiveRiffle( createHiveDriverFactory(), "create table foo (key string)",
+    new HiveRiffle( createHiveDriverFactory(), new String[]{"create table foo (key string)"},
       null, mockSink );
     }
 
@@ -82,7 +82,7 @@ public class HiveRiffleTest extends HiveTestCase
     incoming.add( new Hfs( new NullScheme<JobConf, RecordReader, OutputCollector, Object, Object>(), "/quux/bla" ) );
     Tap outgoing = new Hfs( new NullScheme<JobConf, RecordReader, OutputCollector, Object, Object>(  ), "/out" );
 
-    HiveRiffle riffle = new HiveRiffle( createHiveDriverFactory(), "create table foo (key string)",
+    HiveRiffle riffle = new HiveRiffle( createHiveDriverFactory(), new String[]{"create table foo (key string)"},
       incoming, outgoing );
     assertEquals( incoming, riffle.getIncoming() );
     assertEquals( 1, riffle.getOutgoing().size() );
@@ -102,7 +102,7 @@ public class HiveRiffleTest extends HiveTestCase
     incoming.add( new Hfs( new NullScheme<JobConf, RecordReader, OutputCollector, Object, Object>(), "/quux/bla" ) );
     Tap outgoing = new Hfs( new NullScheme<JobConf, RecordReader, OutputCollector, Object, Object>(  ), "/out" );
 
-    HiveRiffle riffle = new HiveRiffle( factory, "creat table foo (key string)",
+    HiveRiffle riffle = new HiveRiffle( factory, new String[]{"creat table foo (key string)"},
       incoming, outgoing );
     riffle.complete();
     verify( mockDriver ).destroy();
@@ -121,7 +121,7 @@ public class HiveRiffleTest extends HiveTestCase
     incoming.add( new Hfs( new NullScheme<JobConf, RecordReader, OutputCollector, Object, Object>(), "/quux/bla" ) );
     Tap outgoing = new Hfs( new NullScheme<JobConf, RecordReader, OutputCollector, Object, Object>(  ), "/out" );
 
-    HiveRiffle riffle = new HiveRiffle( factory, "creat table foo (key string)",
+    HiveRiffle riffle = new HiveRiffle( factory, new String[]{"creat table foo (key string)"},
       incoming, outgoing );
     riffle.complete();
     verify( mockDriver ).destroy();
@@ -141,7 +141,7 @@ public class HiveRiffleTest extends HiveTestCase
     incoming.add( new Hfs( new NullScheme<JobConf, RecordReader, OutputCollector, Object, Object>(), "/quux/bla" ) );
     Tap outgoing = new Hfs( new NullScheme<JobConf, RecordReader, OutputCollector, Object, Object>(  ), "/out" );
 
-    HiveRiffle riffle = new HiveRiffle( factory, "creat table foo (key string)",
+    HiveRiffle riffle = new HiveRiffle( factory, new String[]{"creat table foo (key string)"},
       incoming, outgoing );
     riffle.complete();
     verify( mockDriver ).destroy();
@@ -158,7 +158,7 @@ public class HiveRiffleTest extends HiveTestCase
     incoming.add( new Hfs( new NullScheme<JobConf, RecordReader, OutputCollector, Object, Object>(), "/quux/bla" ) );
     Tap outgoing = new Hfs( new NullScheme<JobConf, RecordReader, OutputCollector, Object, Object>(  ), "/out" );
 
-    HiveRiffle riffle = new HiveRiffle( factory, "creat table foo (key string)",
+    HiveRiffle riffle = new HiveRiffle( factory, new String[]{"creat table foo (key string)"},
       incoming, outgoing );
     riffle.complete();
     }


### PR DESCRIPTION
HiveQueryRunner now accepts a string with multiple queries separated by  `;` and runs them sequentially in the same context.
