### PR TITLE
Fix serde parameters

### DIFF
--- a/src/main/java/cascading/tap/hive/HiveTableDescriptor.java
+++ b/src/main/java/cascading/tap/hive/HiveTableDescriptor.java
@@ -209,7 +209,8 @@ public class HiveTableDescriptor implements Serializable
     this.columnTypes = columnTypes;
     this.partitionKeys = partitionKeys;
     this.serializationLib = serializationLib;
-    if( delimiter == null )
+    //Only set the delimiter if the serialization lib is Delimited.
+    if( delimiter == null && this.serializationLib == HIVE_DEFAULT_SERIALIZATION_LIB_NAME )
       this.delimiter = HIVE_DEFAULT_DELIMITER;
     else
       this.delimiter = delimiter;
@@ -264,8 +265,16 @@ public class HiveTableDescriptor implements Serializable
     SerDeInfo serDeInfo = new SerDeInfo();
     serDeInfo.setSerializationLib( serializationLib );
     Map<String, String> serDeParameters = new HashMap<String, String>();
-    serDeParameters.put( "serialization.format", getDelimiter() );
-    serDeParameters.put( "field.delim", getDelimiter() );
+
+    if ( getDelimiter() != null)
+      {
+      serDeParameters.put( "serialization.format", getDelimiter() );
+      serDeParameters.put( "field.delim", getDelimiter() );
+      }
+    else
+      {
+      serDeParameters.put( "serialization.format", "1" );
+      }
     serDeInfo.setParameters( serDeParameters );
 
     sd.setSerdeInfo( serDeInfo );


### PR DESCRIPTION
- If the delimiter passed to the HiveTableDescriptor constructor is null it is only set to the default format iff the serialization lib is DELIMITED.
- HiveTableDesciptor now only sets the serde parameters `serialization.format` and `field.delim` to the delimiter  if the delimiter is not null otherwise `serialization.format` is set to `1` inline with default hive behaviour.

This fixes hive displaying the wrong `show create table` output on a non DELIMITED table.
