### PR TITLE
Changes HiveFlows behaviour to be more inline with normal Flow behaviour

### DIFF
--- a/src/main/java/cascading/flow/hive/HiveRiffle.java
+++ b/src/main/java/cascading/flow/hive/HiveRiffle.java
@@ -93,8 +93,7 @@ public class HiveRiffle
   @ProcessComplete
   public void complete()
     {
-    HiveQueryRunner runner = new HiveQueryRunner( driverFactory, queries );
-    runner.run();
+    execute();
     }
 
   @DependencyOutgoing
@@ -109,4 +108,10 @@ public class HiveRiffle
     return sources ;
     }
 
+  public void execute()
+    {
+    HiveQueryRunner runner = new HiveQueryRunner( driverFactory, queries );
+    runner.run();
+    System.out.println("\nQuery finished\n");      
+    }
   }


### PR DESCRIPTION
Changes the start method to run the query asynchronously.
Supports FlowListeners at least for the onStart, onCompleted and onThrowable events.

This is pretty rough. I wasn't sure how to best separate the logic between HiveRiffle and HiveFlow. HiveRiffle seems kind of superfluous now. I also struggled with the access restrictions on a number of core methods in BaseFlow, which meant that I had to reimplement them in HiveFlow.
