### PR TITLE
New HCatTap and HCatScheme

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ dependencies {
 
   compile group: 'cascading', name: 'cascading-hadoop2-mr1', version: cascadingVersion, changing: true
 
-  provided (group: 'org.apache.hive', name: 'hive-exec', version: hiveVersion){
+  provided (group: 'org.apache.hive.hcatalog', name: 'hive-webhcat-java-client', version: hiveVersion){
       exclude group: 'com.google.guava'
   }
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -74,3 +74,20 @@ and has been configured as described on the [Apache Hive Wiki](https://cwiki.apa
 
     >  yarn jar build/libs/cascading-hive-demo-1.0.jar cascading.hive.TransactionalTableDemo
 
+
+## cascading.hive.HCatTapDemo
+
+Demo that copies `access.log` into HDFS and makes it available in Hive as the table `default.access_log`. It
+uses a sink `HCatTap` to copy the data from the file to the table. Then `default.access_log` is read with a
+source `HCatTap` that selects _ASIA_ and _EU_ partitions and counts the number of records for each. The output
+is stored in `hdfs:/tmp/filtered_access.log/`.
+
+### Running this application:
+
+    >  export YARN_OPTS="-Dhive.server.url=jdbc:hive2://localhost:10000/default \
+         -Dhive.server.user=root \
+         -Dhive.server.password=hadoop \
+         -Dhive.metastore.uris=thrift://sandbox.hortonworks.com:9083"
+
+    >  yarn jar build/libs/cascading-hive-demo-1.0.jar cascading.hive.HCatTapDemo
+

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -72,14 +72,14 @@ repositories {
 dependencies {
   // broken hive deps..
   compile group: 'sqlline', name: 'sqlline',  version: '1.1.6'
-  compile group: 'cascading', name: 'cascading-hive', version: '2.0.0-wip-dev'
+  compile group: 'cascading', name: 'cascading-hive', version: '2.1.0-wip-dev'
   compile group: 'com.hotels', name: 'corc-cascading', version: '1.0.0'
 
   compile( group: 'org.apache.hive', name: 'hive-jdbc', version: hiveVersion  ){
     exclude group: 'sqline'
     exclude group: 'org.slf4j'
   }
-  compile( group: 'org.apache.hive', name: 'hive-exec', version: hiveVersion ) {
+  compile( group: 'org.apache.hive.hcatalog', name: 'hive-webhcat-java-client', version: hiveVersion ) {
     exclude group: 'org.slf4j'
   }
   // add the line below, if you use hive 0.10

--- a/demo/src/main/java/cascading/hive/HCatTapDemo.java
+++ b/demo/src/main/java/cascading/hive/HCatTapDemo.java
@@ -1,0 +1,195 @@
+/*
+* Copyright (c) 2007-2016 Concurrent, Inc. All Rights Reserved.
+*
+* Project and contact information: http://www.cascading.org/
+*
+* This file is part of the Cascading project.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package cascading.hive;
+
+import java.lang.reflect.Type;
+import java.net.URL;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+import cascading.flow.Flow;
+import cascading.flow.FlowProcess;
+import cascading.flow.hadoop2.Hadoop2MR1FlowConnector;
+import cascading.operation.aggregator.Count;
+import cascading.pipe.Every;
+import cascading.pipe.GroupBy;
+import cascading.pipe.Pipe;
+import cascading.property.AppProps;
+import cascading.scheme.hadoop.TextDelimited;
+import cascading.scheme.hadoop.TextLine;
+import cascading.scheme.hcatalog.HCatScheme;
+import cascading.tap.SinkMode;
+import cascading.tap.Tap;
+import cascading.tap.hadoop.Hfs;
+import cascading.tap.hcatalog.HCatTap;
+import cascading.tap.hive.HivePartitionTap;
+import cascading.tap.hive.HiveTableDescriptor;
+import cascading.tap.hive.HiveTap;
+import cascading.tuple.Fields;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.JobConf;
+
+/**
+ * Demo app showing {@link HCatTap} as source and sink.
+ */
+public class HCatTapDemo
+  {
+
+  private static URL ACCESS_LOG = HCatTapDemo.class.getResource( "/access.log" );
+  private static String DATABASE_NAME = "default";
+  private static String TABLE_NAME = "access_log";
+
+  public static void main( String[] args ) throws Exception
+    {
+    Class.forName( "org.apache.hive.jdbc.HiveDriver" );
+
+    Properties properties = new Properties();
+    AppProps.setApplicationName( properties, "Cascading HCatTap demo" );
+
+    JobConf jobConf = createJobConf();
+    FileSystem fs = FileSystem.get( jobConf );
+    
+    Path accessLogPath = new Path( "/tmp/access.log" );
+    System.out.println( "Copying file '"+ACCESS_LOG+"' to '"+accessLogPath+"'" );
+    fs.copyFromLocalFile( false, true, new Path( ACCESS_LOG.toURI() ), accessLogPath );
+
+    createTable();
+
+    // Load file into a hive table
+    Fields logFields = new Fields( new String[]{"ts", "customer", "bucket", "operation", "key", "region"},
+        new Type[]{String.class, String.class, String.class, String.class, String.class, String.class} );
+    Tap logFile = new Hfs( new TextDelimited( logFields ), "hdfs:/tmp/access.log" );
+    // Note that default.access_log has been created as a partitioned table by region but this is transparent
+    // to the tap. Partitions will be determined at run time using the values of the 'region' field and
+    // automatically created after sinking the data
+    Tap logTable = new HCatTap( new HCatScheme( logFields ), DATABASE_NAME, TABLE_NAME );
+
+    Pipe copyLogFilePipe = new Pipe( "Copy log file to Hive table" );
+
+    Flow copyLogFileFlow = new Hadoop2MR1FlowConnector().connect( logFile, logTable, copyLogFilePipe );
+    copyLogFileFlow.complete();
+
+    // Output sample data
+    executeQuery( "SELECT * FROM "+DATABASE_NAME+"."+TABLE_NAME+" LIMIT 20" );
+
+    // Filter log data: in this example we only read the 'ts' and 'region' columns in 'ASIA' and 'EU' partitions
+    Fields projectedLogFields = new Fields( new String[]{"ts", "region"}, new Type[]{String.class, String.class} );
+    Tap filteredLogTable = new HCatTap( new HCatScheme( projectedLogFields ), DATABASE_NAME, TABLE_NAME, "region='ASIA' OR region='EU'" );
+
+    Fields region = new Fields( "region", String.class );
+    Fields total = new Fields ( "count", Long.class );
+    Fields filteredLogFields = region.append( total );
+    Tap filteredLogFile = new Hfs( new TextDelimited( filteredLogFields ), "hdfs:/tmp/filtered_access.log", SinkMode.REPLACE );
+
+    Pipe filteredLogFilePipe = new Pipe( "Filter log table and count by region" );
+    filteredLogFilePipe = new GroupBy( filteredLogFilePipe, region );
+    filteredLogFilePipe = new Every( filteredLogFilePipe, new Count(total), filteredLogFields );
+
+    Flow filterLogFileFlow = new Hadoop2MR1FlowConnector().connect( filteredLogTable, filteredLogFile, filteredLogFilePipe );
+    filterLogFileFlow.complete();
+
+    // Output selected data
+    executeQuery( "SELECT COUNT(*), region FROM "+DATABASE_NAME+"."+TABLE_NAME+" WHERE region='ASIA' OR region='EU' GROUP BY region" );
+    }
+
+  private static JobConf createJobConf()
+    {
+    JobConf jobConf = new JobConf();
+    String metastoreUris = System.getProperty( "hive.metastore.uris", "" );
+    if( !metastoreUris.isEmpty() )
+      jobConf.set( "hive.metastore.uris", metastoreUris );
+    return jobConf;
+    }
+
+  private static Connection getConnection() throws SQLException
+    {
+    String url = System.getProperty( "hive.server.url", "jdbc:hive2://" );
+    String user = System.getProperty( "hive.server.user", "" );
+    String password = System.getProperty( "hive.server.password", "" );
+    Connection con = DriverManager.getConnection( url, user, password );
+    return con;
+    }
+
+  private static void executeQuery( String hql ) throws Exception
+    {
+    Connection con = getConnection();
+    Statement stmt = con.createStatement();
+
+    ResultSet rs = stmt.executeQuery( hql );
+    ResultSetMetaData rsmd = rs.getMetaData();
+
+    System.out.println( "----------------------Hive JDBC--------------------------" );
+    System.out.println( "HQL = " + hql );
+    while( rs.next() )
+      {
+      StringBuffer buf = new StringBuffer( "JDBC>>> " );
+      for( int i = 1; i <= rsmd.getColumnCount(); i++ )
+        {
+        buf.append( rsmd.getColumnName( i ) ).append( "=" ).append( rs.getObject( i ) ).append( ", " );
+        }
+      System.out.println( buf.toString() );
+      }
+    System.out.println( "---------------------------------------------------------" );
+
+    stmt.close();
+    con.close();
+    }
+
+  private static void createTable() throws Exception
+    {
+    Connection con = getConnection();
+    Statement stmt = con.createStatement();
+
+    stmt.executeUpdate( "CREATE DATABASE IF NOT EXISTS "+DATABASE_NAME );
+
+    String createTable = new StringBuilder()
+        .append( " CREATE TABLE IF NOT EXISTS "+DATABASE_NAME+"."+TABLE_NAME+" (" )
+        .append( "   ts STRING, " )
+        .append( "   customer STRING, " )
+        .append( "   bucket STRING, " )
+        .append( "   operation STRING, " )
+        .append( "   key STRING " )
+        .append( " ) " )
+        .append( " PARTITIONED BY (region STRING) " )
+        .append( " STORED AS ORC  " )
+        .toString();
+    stmt.executeUpdate( createTable );
+
+    stmt.executeUpdate( "TRUNCATE TABLE "+DATABASE_NAME+"."+TABLE_NAME );
+
+    String dropPartitions = new StringBuilder()
+        .append( " ALTER TABLE "+DATABASE_NAME+"."+TABLE_NAME+" DROP IF EXISTS " )
+        .append( " PARTITION (region='ASIA'), " )
+        .append( " PARTITION (region='EU'), " )
+        .append( " PARTITION (region='US') " )
+        .toString();
+    stmt.executeUpdate( dropPartitions );
+
+    stmt.close();
+    con.close();    
+    }
+  }

--- a/src/main/java/cascading/hadoop/mapred/InputFormatValueCopier.java
+++ b/src/main/java/cascading/hadoop/mapred/InputFormatValueCopier.java
@@ -1,9 +1,7 @@
 /*
-* Copyright (c) 2007-2015 Concurrent, Inc. All Rights Reserved.
+* This file has been created with ideas taken from Twitter's elephant-bird v4.13:
 *
-* Project and contact information: http://www.cascading.org/
-*
-* This file is part of the Cascading project.
+* https://github.com/twitter/elephant-bird/tree/elephant-bird-4.13
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,12 +16,8 @@
 * limitations under the License.
 */
 
-package cascading.flow.hive;
+package cascading.hadoop.mapred;
 
-public class HiveQueryRunnerForTesting extends HiveQueryRunner
-  {
-  public HiveQueryRunnerForTesting( HiveDriverFactory driverFactory, String queries[], boolean fetchQueryResults )
-    {
-    super( driverFactory, queries, fetchQueryResults );
-    }
-  }
+public interface InputFormatValueCopier<T> {
+  public abstract void copyValue(T oldValue, T newValue);
+}

--- a/src/main/java/cascading/hadoop/mapred/InputFormatWrapper.java
+++ b/src/main/java/cascading/hadoop/mapred/InputFormatWrapper.java
@@ -1,0 +1,110 @@
+/*
+* This file has been created with ideas taken from Twitter's elephant-bird v4.13:
+*
+* https://github.com/twitter/elephant-bird/tree/elephant-bird-4.13
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package cascading.hadoop.mapred;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.task.JobContextImpl;
+import org.apache.hadoop.util.ReflectionUtils;
+
+public class InputFormatWrapper<K, V> implements org.apache.hadoop.mapred.InputFormat<K, V> {
+
+  private static final String INPUT_FORMAT_VALUE_COPIER_CLASS = "input.format.value.copier.class";
+  private static final String WRAPPED_MAPREDUCE_INPUT_FORMAT_CLASS = "wrapped.mapreduce.input.format.class";
+  private static final String MAPRED_INPUT_FORMAT_CLASS = "mapred.input.format.class";
+
+  protected InputFormat<K, V> inputFormat;
+  protected InputFormatValueCopier<V> valueCopier = null;
+
+  public static <K, V> void setInputFormat(Configuration conf, Class<? extends InputFormat<K, V>> inputFormatClass) {
+    setInputFormat(conf, inputFormatClass, null);
+  }
+
+  public static <K, V> void setInputFormat(Configuration conf, Class<? extends InputFormat<K, V>> inputFormatClass,
+      Class<? extends InputFormatValueCopier<V>> valueCopierClass) {
+    conf.setClass(WRAPPED_MAPREDUCE_INPUT_FORMAT_CLASS, inputFormatClass, InputFormat.class);
+    conf.setClass(MAPRED_INPUT_FORMAT_CLASS, InputFormatWrapper.class, org.apache.hadoop.mapred.InputFormat.class);
+    if (valueCopierClass != null) {
+      conf.setClass(INPUT_FORMAT_VALUE_COPIER_CLASS, valueCopierClass, InputFormatValueCopier.class);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  InputFormat<K, V> getInputFormat(Configuration conf) {
+    if (inputFormat == null) {
+      @SuppressWarnings("rawtypes")
+      Class<? extends InputFormat> inputFormatClass = conf.getClass(WRAPPED_MAPREDUCE_INPUT_FORMAT_CLASS, null,
+          InputFormat.class);
+      inputFormat = ReflectionUtils.newInstance(inputFormatClass, conf);
+      if (conf.get(INPUT_FORMAT_VALUE_COPIER_CLASS) != null) {
+        @SuppressWarnings("rawtypes")
+        Class<? extends InputFormatValueCopier> copierClass = conf.getClass(INPUT_FORMAT_VALUE_COPIER_CLASS, null,
+            InputFormatValueCopier.class);
+        if (null != copierClass) {
+          valueCopier = ReflectionUtils.newInstance(copierClass, conf);
+        }
+      }
+    }
+    return inputFormat;
+  }
+
+  @Override
+  public RecordReader<K, V> getRecordReader(InputSplit split, JobConf job, Reporter reporter) throws IOException {
+    return new RecordReaderWrapper<K, V>(getInputFormat(job), split, job, reporter, valueCopier);
+  }
+
+  @Override
+  public InputSplit[] getSplits(JobConf job, int numSplits) throws IOException {
+    try {
+      List<org.apache.hadoop.mapreduce.InputSplit> splits = getInputFormat(job)
+          .getSplits(new JobContextImpl(job, null));
+
+      if (splits == null) {
+        return null;
+      }
+
+      InputSplit[] resultSplits = new InputSplit[splits.size()];
+      int i = 0;
+      for (org.apache.hadoop.mapreduce.InputSplit split : splits) {
+        if (split.getClass() == org.apache.hadoop.mapreduce.lib.input.FileSplit.class) {
+          org.apache.hadoop.mapreduce.lib.input.FileSplit mapreduceFileSplit = ((org.apache.hadoop.mapreduce.lib.input.FileSplit) split);
+          resultSplits[i++] = new FileSplit(mapreduceFileSplit.getPath(), mapreduceFileSplit.getStart(),
+              mapreduceFileSplit.getLength(), mapreduceFileSplit.getLocations());
+        } else {
+          InputSplitWrapper wrapper = new InputSplitWrapper(split);
+          wrapper.setConf(job);
+          resultSplits[i++] = wrapper;
+        }
+      }
+
+      return resultSplits;
+
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    }
+  }
+}

--- a/src/main/java/cascading/hadoop/mapred/InputSplitWrapper.java
+++ b/src/main/java/cascading/hadoop/mapred/InputSplitWrapper.java
@@ -1,0 +1,142 @@
+/*
+* This file has been created with ideas taken from Twitter's elephant-bird v4.13:
+*
+* https://github.com/twitter/elephant-bird/tree/elephant-bird-4.13
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package cascading.hadoop.mapred;
+
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.serializer.Deserializer;
+import org.apache.hadoop.io.serializer.SerializationFactory;
+import org.apache.hadoop.io.serializer.Serializer;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.util.ReflectionUtils;
+
+class InputSplitWrapper implements InputSplit, Configurable {
+
+  org.apache.hadoop.mapreduce.InputSplit inputSplit;
+  private Configuration conf;
+
+  public InputSplitWrapper() {
+  }
+
+  public InputSplitWrapper(org.apache.hadoop.mapreduce.InputSplit inputSplit) {
+    this.inputSplit = inputSplit;
+  }
+
+  @Override
+  public long getLength() throws IOException {
+    try {
+      return inputSplit.getLength();
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public String[] getLocations() throws IOException {
+    try {
+      return inputSplit.getLocations();
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    inputSplit = deserializeInputSplit(conf, (DataInputStream) in);
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    serializeInputSplit(conf, (DataOutputStream) out, inputSplit);
+  }
+
+  @Override
+  public void setConf(Configuration conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public Configuration getConf() {
+    return conf;
+  }
+
+  public static void serializeInputSplit(Configuration conf, DataOutputStream out,
+      org.apache.hadoop.mapreduce.InputSplit inputSplit2)
+    throws IOException {
+    Class<? extends InputSplit> clazz = inputSplit2.getClass().asSubclass(InputSplit.class);
+    Text.writeString(out, clazz.getName());
+    SerializationFactory factory = new SerializationFactory(conf);
+    Serializer serializer = factory.getSerializer(clazz);
+    serializer.open(out instanceof UncloseableDataOutputStream ? out : new UncloseableDataOutputStream(out));
+    serializer.serialize(inputSplit2);
+  }
+
+  public static org.apache.hadoop.mapreduce.InputSplit deserializeInputSplit(Configuration conf, DataInputStream in)
+    throws IOException {
+    String name = Text.readString(in);
+    Class<? extends org.apache.hadoop.mapreduce.InputSplit> clazz;
+    try {
+      clazz = conf.getClassByName(name).asSubclass(org.apache.hadoop.mapreduce.InputSplit.class);
+    } catch (ClassNotFoundException e) {
+      throw new IOException("Could not find class for deserialized class name: " + name, e);
+    }
+    return deserializeInputSplitInternal(conf,
+        in instanceof UncloseableDataInputStream ? in : new UncloseableDataInputStream(in), clazz);
+  }
+
+  private static <T extends org.apache.hadoop.mapreduce.InputSplit> T deserializeInputSplitInternal(Configuration conf,
+      DataInputStream in, Class<T> clazz)
+    throws IOException {
+    T split = ReflectionUtils.newInstance(clazz, conf);
+    SerializationFactory factory = new SerializationFactory(conf);
+    Deserializer<T> deserializer = factory.getDeserializer(clazz);
+    deserializer.open(in instanceof UncloseableDataInputStream ? in : new UncloseableDataInputStream(in));
+    return deserializer.deserialize(split);
+  }
+
+  private static class UncloseableDataOutputStream extends DataOutputStream {
+    public UncloseableDataOutputStream(DataOutputStream os) {
+      super(os);
+    }
+
+    @Override
+    public void close() {
+      // We don't want classes given this stream to close it
+    }
+  }
+
+  private static class UncloseableDataInputStream extends DataInputStream {
+    public UncloseableDataInputStream(DataInputStream is) {
+      super(is);
+    }
+
+    @Override
+    public void close() {
+      // We don't want classes given this stream to close it
+    }
+  }
+
+}

--- a/src/main/java/cascading/hadoop/mapred/OutputCommitterWrapper.java
+++ b/src/main/java/cascading/hadoop/mapred/OutputCommitterWrapper.java
@@ -1,0 +1,97 @@
+/*
+* This file has been created with ideas taken from Twitter's elephant-bird v4.13:
+*
+* https://github.com/twitter/elephant-bird/tree/elephant-bird-4.13
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package cascading.hadoop.mapred;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.JobContext;
+import org.apache.hadoop.mapred.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+
+public class OutputCommitterWrapper extends org.apache.hadoop.mapred.OutputCommitter {
+
+  private static final String MAPRED_OUTPUT_COMMITTER_CLASS = "mapred.output.committer.class";
+
+  @SuppressWarnings("rawtypes")
+  private final OutputFormatWrapper outputFormat = new OutputFormatWrapper();
+
+  public static void setOutputCommitter(Configuration conf) {
+    conf.setClass(MAPRED_OUTPUT_COMMITTER_CLASS, OutputCommitterWrapper.class, OutputCommitter.class);
+  }
+
+  public static void unsetOutputCommitter(Configuration conf) {
+    conf.unset(MAPRED_OUTPUT_COMMITTER_CLASS);
+  }
+
+  private OutputCommitter getOutputCommitter(TaskAttemptContext taskAttemptContext) throws IOException {
+    try {
+      Configuration conf = taskAttemptContext.getConfiguration();
+      return outputFormat.getOutputFormat(conf).getOutputCommitter(taskAttemptContext);
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    }
+  }
+
+  private OutputCommitter getOutputCommitter(JobContext jobContext) throws IOException {
+    try {
+      Configuration conf = jobContext.getConfiguration();
+      return outputFormat.getOutputFormat(conf).getOutputCommitter(WrapperUtils.getTaskAttemptContext(jobContext));
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public void setupJob(JobContext jobContext) throws IOException {
+    getOutputCommitter(jobContext).setupJob(jobContext);
+  }
+
+  @Override
+  public void setupTask(TaskAttemptContext taskAttemptContext) throws IOException {
+    getOutputCommitter(taskAttemptContext).setupTask(taskAttemptContext);
+  }
+
+  @Override
+  public boolean needsTaskCommit(TaskAttemptContext taskAttemptContext) throws IOException {
+    return getOutputCommitter(taskAttemptContext).needsTaskCommit(taskAttemptContext);
+  }
+
+  @Override
+  public void commitTask(TaskAttemptContext taskAttemptContext) throws IOException {
+    getOutputCommitter(taskAttemptContext).commitTask(taskAttemptContext);
+  }
+
+  @Override
+  public void abortTask(TaskAttemptContext taskAttemptContext) throws IOException {
+    getOutputCommitter(taskAttemptContext).abortTask(taskAttemptContext);
+  }
+
+  @Override
+  public void abortJob(JobContext jobContext, int status) throws IOException {
+    getOutputCommitter(jobContext).abortJob(jobContext, WrapperUtils.getState(status));
+  }
+
+  @Override
+  public void commitJob(JobContext jobContext) throws IOException {
+    unsetOutputCommitter(jobContext.getConfiguration());
+    getOutputCommitter(jobContext).commitJob(jobContext);
+  }
+
+}

--- a/src/main/java/cascading/hadoop/mapred/OutputFormatWrapper.java
+++ b/src/main/java/cascading/hadoop/mapred/OutputFormatWrapper.java
@@ -1,0 +1,80 @@
+/*
+* This file has been created with ideas taken from Twitter's elephant-bird v4.13:
+*
+* https://github.com/twitter/elephant-bird/tree/elephant-bird-4.13
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package cascading.hadoop.mapred;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordWriter;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.task.JobContextImpl;
+import org.apache.hadoop.util.Progressable;
+import org.apache.hadoop.util.ReflectionUtils;
+
+public class OutputFormatWrapper<K, V> implements org.apache.hadoop.mapred.OutputFormat<K, V> {
+
+  private static final String WRAPPED_MAPREDUCE_OUTPUT_FORMAT_CLASS = "wrapped.mapreduce.output.format.class";
+  private static final String MAPRED_OUTPUT_FORMAT_CLASS = "mapred.output.format.class";
+
+  protected OutputFormat<K, V> outputFormat;
+
+  public static <K, V> void setOutputFormat(Configuration conf, Class<? extends OutputFormat<K, V>> ouputFormatClass) {
+    conf.setClass(WRAPPED_MAPREDUCE_OUTPUT_FORMAT_CLASS, ouputFormatClass, OutputFormat.class);
+    conf.setClass(MAPRED_OUTPUT_FORMAT_CLASS, OutputFormatWrapper.class, org.apache.hadoop.mapred.OutputFormat.class);
+  }
+
+  @SuppressWarnings("unchecked")
+  OutputFormat<K, V> getOutputFormat(Configuration conf) {
+    if (outputFormat == null) {
+      @SuppressWarnings("rawtypes")
+      Class<? extends OutputFormat> outputFormatClass = conf.getClass(WRAPPED_MAPREDUCE_OUTPUT_FORMAT_CLASS, null,
+          OutputFormat.class);
+      outputFormat = ReflectionUtils.newInstance(outputFormatClass, conf);
+    }
+    return outputFormat;
+  }
+
+  @Override
+  public void checkOutputSpecs(FileSystem ignored, JobConf conf) throws IOException {
+    try {
+      JobContext jobContext = new JobContextImpl(conf, null);
+      getOutputFormat(conf).checkOutputSpecs(jobContext);
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public RecordWriter<K, V> getRecordWriter(FileSystem ignored, JobConf conf, String name, Progressable progress)
+    throws IOException {
+    try {
+      TaskAttemptContext taskAttemptContext = WrapperUtils.getTaskAttemptContext(conf);
+      org.apache.hadoop.mapreduce.RecordWriter<K, V> recordWriter = getOutputFormat(conf)
+          .getRecordWriter(taskAttemptContext);
+      return new RecordWriterWrapper<K, V>(recordWriter, taskAttemptContext);
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    }
+  }
+
+}

--- a/src/main/java/cascading/hadoop/mapred/RecordReaderWrapper.java
+++ b/src/main/java/cascading/hadoop/mapred/RecordReaderWrapper.java
@@ -1,0 +1,159 @@
+/*
+* This file has been created with ideas taken from Twitter's elephant-bird v4.13:
+*
+* https://github.com/twitter/elephant-bird/tree/elephant-bird-4.13
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package cascading.hadoop.mapred;
+
+import java.io.IOException;
+
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.task.MapContextImpl;
+
+class RecordReaderWrapper<K, V> implements RecordReader<K, V> {
+
+  private org.apache.hadoop.mapreduce.RecordReader<K, V> recordReader;
+
+  private final long splitLen; // for getPos()
+
+  private K key = null;
+  private V value = null;
+  private final InputFormatValueCopier<V> valueCopier;
+
+  private boolean firstRecord = false;
+  private boolean eof = false;
+
+  public RecordReaderWrapper(InputFormat<K, V> newInputFormat, InputSplit oldSplit, JobConf oldJobConf,
+      Reporter reporter, InputFormatValueCopier<V> valueCopier) throws IOException {
+
+    this.valueCopier = valueCopier;
+    splitLen = oldSplit.getLength();
+
+    org.apache.hadoop.mapreduce.InputSplit split;
+    if (oldSplit.getClass() == FileSplit.class) {
+      split = new org.apache.hadoop.mapreduce.lib.input.FileSplit(((FileSplit) oldSplit).getPath(),
+          ((FileSplit) oldSplit).getStart(), ((FileSplit) oldSplit).getLength(), oldSplit.getLocations());
+    } else {
+      split = ((InputSplitWrapper) oldSplit).inputSplit;
+    }
+
+    TaskAttemptID taskAttemptID = TaskAttemptID.forName(oldJobConf.get("mapred.task.id"));
+    if (taskAttemptID == null) {
+      taskAttemptID = new TaskAttemptID();
+    }
+
+    TaskAttemptContext taskContext = new MapContextImpl<>(oldJobConf, taskAttemptID, null, null, null,
+        new ReporterWrapper(reporter), null);
+    try {
+      recordReader = newInputFormat.createRecordReader(split, taskContext);
+      recordReader.initialize(split, taskContext);
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    }
+  }
+
+  private void initKeyValueObjects() {
+    // read once to gain access to key and value objects
+    try {
+      if (!firstRecord & !eof) {
+        if (recordReader.nextKeyValue()) {
+          firstRecord = true;
+          key = recordReader.getCurrentKey();
+          value = recordReader.getCurrentValue();
+        } else {
+          eof = true;
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Could not read first record (and it was not an EOF)", e);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    recordReader.close();
+  }
+
+  @Override
+  public K createKey() {
+    initKeyValueObjects();
+    return key;
+  }
+
+  @Override
+  public V createValue() {
+    initKeyValueObjects();
+    return value;
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    return (long) (splitLen * getProgress());
+  }
+
+  @Override
+  public float getProgress() throws IOException {
+    try {
+      return recordReader.getProgress();
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public boolean next(K key, V value) throws IOException {
+    if (eof) {
+      return false;
+    }
+
+    if (firstRecord) { // key & value are already read.
+      firstRecord = false;
+      return true;
+    }
+
+    try {
+      if (recordReader.nextKeyValue()) {
+
+        if (key != recordReader.getCurrentKey()) {
+          throw new IOException("InputFormatWrapper only supports RecordReaders that return the same key objects. "
+              + "Current reader class : " + recordReader.getClass());
+        }
+
+        if (value != recordReader.getCurrentValue()) {
+          if (valueCopier == null) {
+            throw new IOException("InputFormatWrapper only supports RecordReaders that return the same value objects "
+                + "unless a InputFormatValueCopier is provided. Current reader class : " + recordReader.getClass());
+          }
+          valueCopier.copyValue(value, recordReader.getCurrentValue());
+        }
+
+        return true;
+      }
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    }
+
+    eof = true; // strictly not required, just for consistency
+    return false;
+  }
+}

--- a/src/main/java/cascading/hadoop/mapred/RecordWriterWrapper.java
+++ b/src/main/java/cascading/hadoop/mapred/RecordWriterWrapper.java
@@ -1,0 +1,55 @@
+/*
+* This file has been created with ideas taken from Twitter's elephant-bird v4.13:
+*
+* https://github.com/twitter/elephant-bird/tree/elephant-bird-4.13
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package cascading.hadoop.mapred;
+
+import java.io.IOException;
+
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+class RecordWriterWrapper<K, V> implements org.apache.hadoop.mapred.RecordWriter<K, V> {
+
+  private final RecordWriter<K, V> recordWriter;
+  private final TaskAttemptContext taskAttemptContext;
+
+  RecordWriterWrapper(RecordWriter<K, V> recordWriter, TaskAttemptContext taskAttemptContext) {
+    this.recordWriter = recordWriter;
+    this.taskAttemptContext = taskAttemptContext;
+  }
+
+  @Override
+  public void close(Reporter reporter) throws IOException {
+    try {
+      recordWriter.close(taskAttemptContext);
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public void write(K key, V value) throws IOException {
+    try {
+      recordWriter.write(key, value);
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    }
+  }
+
+}

--- a/src/main/java/cascading/hadoop/mapred/ReporterWrapper.java
+++ b/src/main/java/cascading/hadoop/mapred/ReporterWrapper.java
@@ -1,0 +1,72 @@
+/*
+* This file has been created with ideas taken from Twitter's elephant-bird v4.13:
+*
+* https://github.com/twitter/elephant-bird/tree/elephant-bird-4.13
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package cascading.hadoop.mapred;
+
+import org.apache.hadoop.mapred.Counters;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapreduce.StatusReporter;
+
+public class ReporterWrapper extends StatusReporter implements Reporter {
+  private final Reporter reporter;
+
+  public ReporterWrapper(Reporter reporter) {
+    this.reporter = reporter;
+  }
+
+  @Override
+  public Counters.Counter getCounter(Enum<?> name) {
+    return reporter.getCounter(name);
+  }
+
+  @Override
+  public Counters.Counter getCounter(String group, String name) {
+    return reporter.getCounter(group, name);
+  }
+
+  @Override
+  public void incrCounter(Enum<?> key, long amount) {
+    reporter.incrCounter(key, amount);
+  }
+
+  @Override
+  public void incrCounter(String group, String counter, long amount) {
+    reporter.incrCounter(group, counter, amount);
+  }
+
+  @Override
+  public InputSplit getInputSplit() throws UnsupportedOperationException {
+    return reporter.getInputSplit();
+  }
+
+  @Override
+  public void progress() {
+    reporter.progress();
+  }
+
+  @Override
+  public float getProgress() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setStatus(String status) {
+    reporter.setStatus(status);
+  }
+}

--- a/src/main/java/cascading/hadoop/mapred/WrapperUtils.java
+++ b/src/main/java/cascading/hadoop/mapred/WrapperUtils.java
@@ -1,0 +1,56 @@
+/*
+* This file has been created with ideas taken from Twitter's elephant-bird v4.13:
+*
+* https://github.com/twitter/elephant-bird/tree/elephant-bird-4.13
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package cascading.hadoop.mapred;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.JobContext;
+import org.apache.hadoop.mapreduce.JobStatus.State;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.TaskID;
+import org.apache.hadoop.mapreduce.TaskType;
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
+
+final class WrapperUtils {
+
+  private WrapperUtils() {
+  }
+
+  static TaskAttemptContext getTaskAttemptContext(Configuration conf) {
+    TaskAttemptID taskAttemptID = TaskAttemptID.forName(conf.get("mapred.task.id"));
+    return new TaskAttemptContextImpl(conf, taskAttemptID);
+  }
+
+  static TaskAttemptContext getTaskAttemptContext(JobContext jobContext) {
+    Configuration conf = jobContext.getConfiguration();
+    TaskID taskId = new org.apache.hadoop.mapreduce.TaskID(jobContext.getJobID(), TaskType.MAP, 0);
+    TaskAttemptID taskAttemptId = new org.apache.hadoop.mapreduce.TaskAttemptID(taskId, 0);
+    return new TaskAttemptContextImpl(conf, taskAttemptId);
+  }
+
+  static State getState(int status) {
+    for (State value : State.values()) {
+      if (value.getValue() == status) {
+        return value;
+      }
+    }
+    throw new IllegalStateException("Unknown status: " + status);
+  }
+
+}

--- a/src/main/java/cascading/scheme/hcatalog/HCatScheme.java
+++ b/src/main/java/cascading/scheme/hcatalog/HCatScheme.java
@@ -1,0 +1,201 @@
+/*
+* Copyright (c) 2007-2016 Concurrent, Inc. All Rights Reserved.
+*
+* Project and contact information: http://www.cascading.org/
+*
+* This file is part of the Cascading project.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package cascading.scheme.hcatalog;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.WritableComparable;
+import org.apache.hadoop.mapred.OutputCollector;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hive.hcatalog.common.HCatConstants;
+import org.apache.hive.hcatalog.common.HCatUtil;
+import org.apache.hive.hcatalog.data.DefaultHCatRecord;
+import org.apache.hive.hcatalog.data.HCatRecord;
+import org.apache.hive.hcatalog.data.schema.HCatSchema;
+import org.apache.hive.hcatalog.mapreduce.HCatBaseOutputFormat;
+import org.apache.hive.hcatalog.mapreduce.HCatInputFormat;
+import org.apache.hive.hcatalog.mapreduce.HCatOutputFormat;
+import org.apache.hive.hcatalog.mapreduce.HCatTableInfo;
+import org.apache.hive.hcatalog.mapreduce.OutputJobInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import cascading.flow.FlowProcess;
+import cascading.hadoop.mapred.OutputCommitterWrapper;
+import cascading.scheme.Scheme;
+import cascading.scheme.SinkCall;
+import cascading.scheme.SourceCall;
+import cascading.scheme.hcatalog.HCatScheme.SourceContext;
+import cascading.tap.Tap;
+import cascading.tap.hcatalog.HCatTap;
+import cascading.tuple.Fields;
+import cascading.tuple.TupleEntry;
+
+/**
+ * A {@link Scheme} to be used in conjunction with {@link HCatTap}.
+ * <p>
+ * Use this {@link Scheme} to specify the {@link Fields} to read from a Hive table. {@code HCatScheme} uses HCatalog to
+ * perform metadata validations and simplify the processing of the records.
+ * </p>
+ * <p>
+ * Each field is mapped to a column of the same name in the Hive table so the {@linkplain Fields fields} type must match
+ * the Hive column type.
+ * </p>
+ * <p>
+ * Note that Cascading {@link Fields} are case-sensitive whereas Hive column names are case-insensitive. This
+ * {@link Scheme} makes sure that no duplicate {@linkplain Fields field} names are selected. If two or more
+ * {@linkplain Fields fields} have the same case-insensitive name then the {@link Scheme} will throw an
+ * {@link Exception}.
+ * </p>
+ *
+ * @since 2.1
+ */
+public class HCatScheme extends Scheme<Configuration, RecordReader, OutputCollector, SourceContext, HCatSchema> {
+
+  private static final long serialVersionUID = 1L;
+
+  private static final Logger LOG = LoggerFactory.getLogger(HCatScheme.class);
+
+  /**
+   * Creates a new {@link HCatScheme}.
+   *
+   * @param fields Selected {@link Fields}. Field names and type must match their equivalent in the Hive table.
+   * @throws {@link IllegalArgumentException} If duplicate case-insensitive names are set in {@code fields}.
+   */
+  public HCatScheme(Fields fields) {
+    super(fields, fields);
+    SchemaUtils.getLowerCaseFieldNames(fields); // fail-fast on case insensitive duplicates
+  }
+
+  @Override
+  public void sourceConfInit(FlowProcess<? extends Configuration> flowProcess,
+      Tap<Configuration, RecordReader, OutputCollector> tap, Configuration conf) {
+    try {
+      HCatSchema partitionColumns = HCatInputFormat.getPartitionColumns(conf);
+      HCatSchema dataColumns = HCatInputFormat.getDataColumns(conf);
+      HCatSchema schema = SchemaUtils.getSourceSchema(partitionColumns, dataColumns, getSourceFields());
+      // This is equivalent to HCatBaseInputFormat.setOutputSchema
+      conf.set(HCatConstants.HCAT_KEY_OUTPUT_SCHEMA, HCatUtil.serialize(schema));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void sourcePrepare(FlowProcess<? extends Configuration> flowProcess,
+      SourceCall<SourceContext, RecordReader> sourceCall)
+    throws IOException {
+    Configuration conf = flowProcess.getConfig();
+
+    HCatSchema partitionColumns = HCatInputFormat.getPartitionColumns(conf);
+    HCatSchema dataColumns = HCatInputFormat.getDataColumns(conf);
+    HCatSchema schema = SchemaUtils.getSourceSchema(partitionColumns, dataColumns, getSourceFields());
+
+    WritableComparable<?> key = (WritableComparable<?>) sourceCall.getInput().createKey();
+    HCatRecord record = (HCatRecord) sourceCall.getInput().createValue();
+    sourceCall.setContext(new SourceContext(schema, key, record));
+  }
+
+  @Override
+  public boolean source(FlowProcess<? extends Configuration> flowProcess,
+      SourceCall<SourceContext, RecordReader> sourceCall)
+    throws IOException {
+    WritableComparable<?> key = sourceCall.getContext().key;
+    HCatRecord record = sourceCall.getContext().record;
+
+    if (!sourceCall.getInput().next(key, record)) {
+      return false;
+    }
+
+    HCatSchema schema = sourceCall.getContext().schema;
+    TupleEntry entry = sourceCall.getIncomingEntry();
+
+    Fields fields = getSourceFields();
+    for (Comparable<?> field : fields) {
+      Object value = record.get(field.toString(), schema);
+      entry.setObject(field, value);
+    }
+
+    return true;
+  }
+
+  @Override
+  public void sinkConfInit(FlowProcess<? extends Configuration> flowProcess,
+      Tap<Configuration, RecordReader, OutputCollector> tap, Configuration conf) {
+    OutputCommitterWrapper.setOutputCommitter(conf);
+
+    try {
+      OutputJobInfo outputJobInfo = HCatBaseOutputFormat.getJobInfo(conf);
+      HCatTableInfo tableInfo = outputJobInfo.getTableInfo();
+      HCatSchema schema = SchemaUtils.getSinkSchema(tableInfo.getPartitionColumns(), tableInfo.getDataColumns(),
+          getSinkFields());
+      HCatOutputFormat.setSchema(conf, schema);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void sinkPrepare(FlowProcess<? extends Configuration> flowProcess,
+      SinkCall<HCatSchema, OutputCollector> sinkCall)
+    throws IOException {
+    Configuration conf = flowProcess.getConfig();
+    OutputCommitterWrapper.unsetOutputCommitter(conf);
+
+    OutputJobInfo outputJobInfo = HCatBaseOutputFormat.getJobInfo(conf);
+    HCatTableInfo tableInfo = outputJobInfo.getTableInfo();
+    HCatSchema schema = SchemaUtils.getSinkSchema(tableInfo.getPartitionColumns(), tableInfo.getDataColumns(),
+        getSinkFields());
+    sinkCall.setContext(schema);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void sink(FlowProcess<? extends Configuration> flowProcess, SinkCall<HCatSchema, OutputCollector> sinkCall)
+    throws IOException {
+    HCatSchema schema = sinkCall.getContext();
+    TupleEntry entry = sinkCall.getOutgoingEntry();
+    HCatRecord record = new DefaultHCatRecord(schema.size());
+
+    Fields fields = getSinkFields();
+    for (Comparable<?> field : fields) {
+      Object value = entry.getObject(field);
+      record.set(field.toString(), schema, value);
+    }
+
+    sinkCall.getOutput().collect(null, record);
+  }
+
+  static class SourceContext {
+    private final HCatSchema schema;
+    private final WritableComparable<?> key;
+    private final HCatRecord record;
+
+    SourceContext(HCatSchema schema, WritableComparable<?> key, HCatRecord record) {
+      this.schema = schema;
+      this.key = key;
+      this.record = record;
+    }
+
+  }
+
+}

--- a/src/main/java/cascading/scheme/hcatalog/SchemaUtils.java
+++ b/src/main/java/cascading/scheme/hcatalog/SchemaUtils.java
@@ -1,0 +1,152 @@
+/*
+* Copyright (c) 2007-2016 Concurrent, Inc. All Rights Reserved.
+*
+* Project and contact information: http://www.cascading.org/
+*
+* This file is part of the Cascading project.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package cascading.scheme.hcatalog;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.hive.hcatalog.data.schema.HCatFieldSchema;
+import org.apache.hive.hcatalog.data.schema.HCatSchema;
+
+import cascading.tuple.Fields;
+
+/**
+ * A set of static convenient methods for working with {@link HCatSchema}.
+ */
+final class SchemaUtils {
+
+  private SchemaUtils() {
+  }
+
+  /**
+   * Returns a {@link Set} of lower-case column names from the given {@link Fields}.
+   * <p>
+   * Column names are case-insensitive unique {@link String strings}.
+   * </p>
+   *
+   * @param fields Cascading {@linkplain Fields fields} that should map to column names.
+   * @throws {@code IllegalArgumentException} If {@code fields} contains ignore-case duplicates.
+   */
+  public static Set<String> getLowerCaseFieldNames(Fields fields) {
+    Set<String> names = new HashSet<>(fields.size());
+    Set<String> duplicates = new HashSet<>(fields.size());
+    for (Comparable<?> name : fields) {
+      String lowerCaseName = name.toString().toLowerCase();
+      if (!names.add(lowerCaseName)) {
+        duplicates.add(lowerCaseName);
+      }
+    }
+    if (duplicates.size() > 0) {
+      throw new IllegalArgumentException(
+          String.format("Duplicate field name(s) found %s. HCatalog is case insensitive.", duplicates));
+    }
+    return Collections.unmodifiableSet(names);
+  }
+
+  /**
+   * Returns a {@link HCatSchema} that describe a source Hive table, containing both the given of partition columns and
+   * the given set of data columns.
+   *
+   * @param partitionColumns Partition columns of the Hive table.
+   * @param dataColumns Data columns of the Hive table.
+   * @param fields A set of {@link Fields fields} that must map to both partition and data columns.
+   * @return A {@link HCatScheme} with both partition and data columns.
+   * @throws {@code IllegalArgumentException} If at least one {@code partitionColumns} or {@code dataColumns} is missing
+   *           or not present in {@code fields}.
+   */
+  public static HCatSchema getSourceSchema(HCatSchema partitionColumns, HCatSchema dataColumns, Fields fields) {
+    Set<String> names = getLowerCaseFieldNames(fields);
+    return getSchema(partitionColumns, dataColumns, names);
+  }
+
+  /**
+   * Returns a {@link HCatSchema} that describe a sink Hive table, containing both the given set of partition columns
+   * and the given set of data columns.
+   * <p>
+   * All partition columns must be present in {@code fields}
+   * </p>
+   *
+   * @param partitionColumns Partition columns of the Hive table.
+   * @param dataColumns Data columns of the Hive table.
+   * @param fields A set of {@link Fields fields} that must map to both partition and data columns.
+   * @return A {@link HCatScheme} with both partition and data columns.
+   * @throws {@code IllegalArgumentException} If at least one {@code partitionColumns} or {@code dataColumns} is missing
+   *           or not present in {@code fields}.
+   */
+  public static HCatSchema getSinkSchema(HCatSchema partitionColumns, HCatSchema dataColumns, Fields fields) {
+    Set<String> names = getLowerCaseFieldNames(fields);
+
+    Set<String> remainingNames = new HashSet<>(partitionColumns.getFieldNames());
+    for (String name : partitionColumns.getFieldNames()) {
+      if (names.contains(name)) {
+        remainingNames.remove(name);
+      }
+    }
+    if (remainingNames.size() > 0) {
+      throw new IllegalArgumentException(String.format("Partition columns are mandatory but %s %s not specified.",
+          remainingNames, remainingNames.size() == 1 ? "was" : "were"));
+    }
+
+    return getSchema(partitionColumns, dataColumns, names);
+
+  }
+
+  /**
+   * Returns a {@link HCatSchema} that describe the Hive table, containing both the given set of partition columns and
+   * the given set of data columns.
+   * <p>
+   * Both {@code partitionColumns} and {@code dataColumns} are validated against the expected set of column
+   * {@code names} .
+   * </p>
+   *
+   * @param partitionColumns Partition columns of the Hive table.
+   * @param dataColumns Data columns of the Hive table.
+   * @param names A {@link Set} of expected column names.
+   * @return A {@link HCatScheme} with both partition and data columns.
+   * @throws {@code IllegalArgumentException} If at least one {@code partitionColumns} or {@code dataColumns} is missing
+   *           or not present in {@code names}.
+   */
+  private static HCatSchema getSchema(HCatSchema partitionColumns, HCatSchema dataColumns, Set<String> names) {
+    List<HCatFieldSchema> columns = new ArrayList<>(names.size());
+
+    Set<String> remainingNames = new HashSet<>(names);
+    for (HCatFieldSchema column : partitionColumns.getFields()) {
+      if (remainingNames.remove(column.getName())) {
+        columns.add(column);
+      }
+    }
+    for (HCatFieldSchema column : dataColumns.getFields()) {
+      if (remainingNames.remove(column.getName())) {
+        columns.add(column);
+      }
+    }
+    if (remainingNames.size() > 0) {
+      throw new IllegalArgumentException(String
+          .format("The following columns were specified but do not exist in the HCatalog table: %s.", remainingNames));
+    }
+
+    return new HCatSchema(columns);
+  }
+
+}

--- a/src/main/java/cascading/tap/hcatalog/HCatInputFormatValueCopier.java
+++ b/src/main/java/cascading/tap/hcatalog/HCatInputFormatValueCopier.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2007-2015 Concurrent, Inc. All Rights Reserved.
+* Copyright (c) 2007-2016 Concurrent, Inc. All Rights Reserved.
 *
 * Project and contact information: http://www.cascading.org/
 *
@@ -18,12 +18,20 @@
 * limitations under the License.
 */
 
-package cascading.flow.hive;
+package cascading.tap.hcatalog;
 
-public class HiveQueryRunnerForTesting extends HiveQueryRunner
-  {
-  public HiveQueryRunnerForTesting( HiveDriverFactory driverFactory, String queries[], boolean fetchQueryResults )
-    {
-    super( driverFactory, queries, fetchQueryResults );
+import org.apache.hive.hcatalog.common.HCatException;
+import org.apache.hive.hcatalog.data.HCatRecord;
+
+import cascading.hadoop.mapred.InputFormatValueCopier;
+
+public class HCatInputFormatValueCopier implements InputFormatValueCopier<HCatRecord> {
+  @Override
+  public void copyValue(HCatRecord oldValue, HCatRecord newValue) {
+    try {
+      oldValue.copy(newValue);
+    } catch (HCatException e) {
+      throw new RuntimeException(e);
     }
   }
+}

--- a/src/main/java/cascading/tap/hcatalog/HCatTap.java
+++ b/src/main/java/cascading/tap/hcatalog/HCatTap.java
@@ -1,0 +1,199 @@
+/*
+* Copyright (c) 2007-2016 Concurrent, Inc. All Rights Reserved.
+*
+* Project and contact information: http://www.cascading.org/
+*
+* This file is part of the Cascading project.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package cascading.tap.hcatalog;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.OutputCollector;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hive.hcatalog.api.HCatClient;
+import org.apache.hive.hcatalog.api.HCatTable;
+import org.apache.hive.hcatalog.api.ObjectNotFoundException;
+import org.apache.hive.hcatalog.mapreduce.HCatInputFormat;
+import org.apache.hive.hcatalog.mapreduce.HCatOutputFormat;
+import org.apache.hive.hcatalog.mapreduce.OutputJobInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import cascading.flow.FlowProcess;
+import cascading.hadoop.mapred.InputFormatWrapper;
+import cascading.hadoop.mapred.OutputFormatWrapper;
+import cascading.scheme.hcatalog.HCatScheme;
+import cascading.tap.SinkMode;
+import cascading.tap.Tap;
+import cascading.tap.hadoop.io.HadoopTupleEntrySchemeCollector;
+import cascading.tap.hadoop.io.HadoopTupleEntrySchemeIterator;
+import cascading.tuple.Fields;
+import cascading.tuple.Tuple;
+import cascading.tuple.TupleEntryCollector;
+import cascading.tuple.TupleEntryIterator;
+
+/**
+ * A HCatalog-backed {@link Tap} that represents a Hive table and that can be used as both source and sink.
+ * <p>
+ * When used as a source {@link Tap} it allows the use of features like partition pruning and column projection (if the
+ * underlying file format backing the Hive tables support this).
+ * </p>
+ * <p>
+ * When used as a sink {@link Tap} it uses
+ * <a href="https://cwiki.apache.org/confluence/display/Hive/DynamicPartitions">Dynamic Partitions</a> to store the data
+ * in the correct partition paths. Partitions are determine at runtime using the {@link Fields} representation of the
+ * partition columns in {@link HCatScheme}. For example if a table is defined as:<br/>
+ * <code>
+ * CREATE TABLE mytable {
+ *   c INT
+ * }
+ * PARTITIONED BY (p STRING)
+ * </code><br/>
+ * column {@code p} must be provided with {@link HCatScheme} therefore when the {@linkplain Tuple tuples}
+ * {@code (c=1,p='A')} and {@code (c=2,p='B')} are collected they will go to partitions {@code p='A'} and {@code p='B'}
+ * respectively.
+ * </p>
+ * <p>
+ * Note this {@link Tap} assumes that the Hive table exists.
+ * </p>
+ *
+ * @since 2.1
+ */
+public class HCatTap extends Tap<Configuration, RecordReader, OutputCollector> {
+
+  private static final long serialVersionUID = 1L;
+
+  private static final Logger LOG = LoggerFactory.getLogger(HCatTap.class);
+
+  private final String databaseName;
+  private final String tableName;
+  private final String filter;
+
+  /**
+   * Constructs a new {@link HCatTap} with no partition filter.
+   * <p>
+   * This is a convenient constructor for sink {@linkplain Tap Taps} where a partition filter is not required and
+   * ignored.
+   * </p>
+   * <p>
+   * This is equivalent to: <br/>
+   * {@code new HCatTap(scheme, databaseName, tableName, null);}
+   * </p>
+   *
+   * @param scheme {@link HCatScheme} that describes the columns to be used.
+   * @param databaseName Name of the Hive database where {@code tableName} is defined.
+   * @param tableName Name of the Hive table that this {@link Tap} represents.
+   */
+  public HCatTap(HCatScheme scheme, String databaseName, String tableName) {
+    this(scheme, databaseName, tableName, null);
+  }
+
+  /**
+   * Constructs a new {@link HCatTap}.
+   * <p>
+   * This constructor should be use by source {@linkplain Tap Taps} when partition filtering is required. See <a href=
+   * "https://cwiki.apache.org/confluence/display/Hive/Hbase+execution+plans+for+RawStore+partition+filter+condition">
+   * HCatalog filter expressions</a> for details about the {@code filter} format.
+   * </p>
+   *
+   * @param scheme {@link HCatScheme} that describes the columns to be used.
+   * @param databaseName Name of the Hive database where {@code tableName} is defined.
+   * @param tableName Name of the Hive table that this {@link Tap} represents.
+   * @param filter A partition-selector expression.
+   */
+  public HCatTap(HCatScheme scheme, String databaseName, String tableName, String filter) {
+    super(scheme, SinkMode.KEEP); // KEEP prevents Cascading from calling deleteResource()
+    this.databaseName = databaseName;
+    this.tableName = tableName;
+    this.filter = filter;
+  }
+
+  @Override
+  public String getIdentifier() {
+    return String.format("hcatalog://%s.%s", databaseName, tableName);
+  }
+
+  @Override
+  public void sourceConfInit(FlowProcess<? extends Configuration> flowProcess, Configuration conf) {
+    InputFormatWrapper.setInputFormat(conf, HCatInputFormat.class, HCatInputFormatValueCopier.class);
+    try {
+      HCatInputFormat.setInput(conf, databaseName, tableName, filter);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    super.sourceConfInit(flowProcess, conf);
+  }
+
+  @Override
+  public TupleEntryIterator openForRead(FlowProcess<? extends Configuration> flowProcess, RecordReader input)
+    throws IOException {
+    return new HadoopTupleEntrySchemeIterator(flowProcess, this, input);
+  }
+
+  @Override
+  public void sinkConfInit(FlowProcess<? extends Configuration> flowProcess, Configuration conf) {
+    OutputFormatWrapper.setOutputFormat(conf, HCatOutputFormat.class);
+    OutputJobInfo outputJobInfo = OutputJobInfo.create(databaseName, tableName, null);
+    try {
+      HCatOutputFormat.setOutput(conf, ((JobConf) conf).getCredentials(), outputJobInfo);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    super.sinkConfInit(flowProcess, conf);
+  }
+
+  @Override
+  public TupleEntryCollector openForWrite(FlowProcess<? extends Configuration> flowProcess, OutputCollector output)
+    throws IOException {
+    return new HadoopTupleEntrySchemeCollector(flowProcess, this, output);
+  }
+
+  @Override
+  public boolean resourceExists(Configuration conf) throws IOException {
+    HCatClient client = HCatClient.create(conf);
+    try {
+      client.getTable(databaseName, tableName);
+    } catch (ObjectNotFoundException e) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public boolean createResource(Configuration conf) throws IOException {
+    return false;
+  }
+
+  @Override
+  public boolean deleteResource(Configuration conf) throws IOException {
+    return false;
+  }
+
+  @Override
+  public long getModifiedTime(Configuration conf) throws IOException {
+    HCatClient client = HCatClient.create(conf);
+    HCatTable table = client.getTable(databaseName, tableName);
+    String lastModifiedTime = table.getTblProps().get("last_modified_time");
+    if (lastModifiedTime == null) {
+      return System.currentTimeMillis();
+    }
+    return Long.parseLong(lastModifiedTime);
+  }
+
+}

--- a/src/test/java/cascading/HiveTestCase.java
+++ b/src/test/java/cascading/HiveTestCase.java
@@ -22,6 +22,7 @@ package cascading;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import cascading.flow.hive.HiveDriverFactory;
 import cascading.flow.hive.HiveQueryRunner;
@@ -46,6 +47,8 @@ import org.junit.rules.TemporaryFolder;
  */
 abstract public class HiveTestCase extends PlatformTestCase
   {
+  private static final long serialVersionUID = 1L;
+
   public final static File DERBY_HOME = new File( "build/test/derby" );
 
   @Rule
@@ -90,11 +93,13 @@ abstract public class HiveTestCase extends PlatformTestCase
   /**
    * Method for running ad-hoc query in tests.
    * @param query
+   * @return query results
    */
-  public void runHiveQuery( String query )
+  public List<Object> runHiveQuery( String query )
     {
-    HiveQueryRunner runner = new HiveQueryRunnerForTesting( hiveDriverFactory, new String[]{query} );
+    HiveQueryRunner runner = new HiveQueryRunnerForTesting( hiveDriverFactory, new String[]{query}, true );
     runner.run();
+    return runner.getQueryResults()[0];
     }
 
   /**

--- a/src/test/java/cascading/scheme/hcatalog/HCatSchemeTest.java
+++ b/src/test/java/cascading/scheme/hcatalog/HCatSchemeTest.java
@@ -1,0 +1,142 @@
+/*
+* Copyright (c) 2007-2016 Concurrent, Inc. All Rights Reserved.
+*
+* Project and contact information: http://www.cascading.org/
+*
+* This file is part of the Cascading project.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package cascading.scheme.hcatalog;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapred.OutputCollector;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hive.hcatalog.common.HCatException;
+import org.apache.hive.hcatalog.data.DefaultHCatRecord;
+import org.apache.hive.hcatalog.data.HCatRecord;
+import org.apache.hive.hcatalog.data.schema.HCatSchema;
+import org.apache.hive.hcatalog.data.schema.HCatSchemaUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import cascading.flow.FlowProcess;
+import cascading.scheme.SinkCall;
+import cascading.scheme.SourceCall;
+import cascading.scheme.hcatalog.HCatScheme.SourceContext;
+import cascading.tuple.Fields;
+import cascading.tuple.Tuple;
+import cascading.tuple.TupleEntry;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HCatSchemeTest {
+
+  private @Mock FlowProcess<? extends Configuration> flowProcess;
+  private @Mock SourceCall<SourceContext, RecordReader> sourceCall;
+  private @Mock RecordReader recordReader;
+  private @Mock SinkCall<HCatSchema, OutputCollector> sinkCall;
+  private @Mock OutputCollector outputCollector;
+  private HCatSchema schema;
+
+  @Before
+  public void init() throws HCatException {
+    List<FieldSchema> fieldSchemas = new ArrayList<>(3);
+    fieldSchemas.add(new FieldSchema("foo", "string", null));
+    fieldSchemas.add(new FieldSchema("bar", "int", null));
+    fieldSchemas.add(new FieldSchema("baz", "int", null));
+    fieldSchemas.add(new FieldSchema("zap", "string", null));
+    schema = HCatSchemaUtils.getHCatSchema(fieldSchemas);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void duplicateFields() {
+    new HCatScheme(new Fields("FOO", "foo"));
+  }
+
+  @Test
+  public void source() throws IOException {
+    NullWritable key = NullWritable.get();
+    HCatRecord record = new DefaultHCatRecord(4);
+    record.set(0, "I am foo");
+    record.set(1, 4);
+    record.set(2, 6);
+    record.set(3, "I am zap");
+    SourceContext context = new SourceContext(schema, key, record);
+    when(sourceCall.getContext()).thenReturn(context);
+
+    when(recordReader.next(any(), any())).thenReturn(true);
+
+    Fields fields = new Fields(new String[] { "zap", "foo", "baz", "bar" },
+        new Type[] { String.class, String.class, Integer.class, Integer.class });
+    TupleEntry tupleEntry = new TupleEntry(fields, new Tuple(null, null, null, null));
+    when(sourceCall.getIncomingEntry()).thenReturn(tupleEntry);
+    when(sourceCall.getInput()).thenReturn(recordReader);
+
+    HCatScheme scheme = new HCatScheme(fields);
+    assertTrue(scheme.source(flowProcess, sourceCall));
+
+    assertEquals("I am foo", tupleEntry.getString("foo"));
+    assertEquals(4, tupleEntry.getInteger("bar"));
+    assertEquals(6, tupleEntry.getInteger("baz"));
+    assertEquals("I am zap", tupleEntry.getString("zap"));
+  }
+
+  @Test
+  public void sink() throws IOException {
+    when(sinkCall.getContext()).thenReturn(schema);
+
+    Fields fields = new Fields(new String[] { "bar", "foo", "zap" },
+        new Type[] { Integer.class, String.class, String.class });
+    Tuple tuple = new Tuple(1, "I am foo", "I am zap");
+    when(sinkCall.getOutgoingEntry()).thenReturn(new TupleEntry(fields, tuple));
+
+    when(sinkCall.getOutput()).thenReturn(outputCollector);
+
+    ArgumentCaptor<Object> outputKey = ArgumentCaptor.forClass(Object.class);
+    ArgumentCaptor<Object> outputValue = ArgumentCaptor.forClass(Object.class);
+
+    HCatScheme scheme = new HCatScheme(fields);
+    scheme.sink(flowProcess, sinkCall);
+
+    verify(outputCollector).collect(outputKey.capture(), outputValue.capture());
+    assertNull(outputKey.getValue());
+    HCatRecord output = (HCatRecord) outputValue.getValue();
+    assertNotNull(output);
+    assertEquals(4, output.size());
+    assertEquals("I am foo", output.get(0));
+    assertEquals(1, output.get(1));
+    assertNull(output.get(2));
+    assertEquals("I am zap", output.get(3));
+  }
+
+}

--- a/src/test/java/cascading/scheme/hcatalog/SchemaUtilsTest.java
+++ b/src/test/java/cascading/scheme/hcatalog/SchemaUtilsTest.java
@@ -1,0 +1,151 @@
+/*
+* Copyright (c) 2007-2016 Concurrent, Inc. All Rights Reserved.
+*
+* Project and contact information: http://www.cascading.org/
+*
+* This file is part of the Cascading project.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package cascading.scheme.hcatalog;
+
+import static junit.framework.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hive.hcatalog.common.HCatException;
+import org.apache.hive.hcatalog.data.schema.HCatFieldSchema;
+import org.apache.hive.hcatalog.data.schema.HCatSchema;
+import org.junit.Test;
+
+import cascading.tuple.Fields;
+
+public class SchemaUtilsTest {
+
+  private static final String FOO = "foo";
+  private static final String BAR = "bar";
+  private static final String BAZ = "baz";
+
+  private static final HCatFieldSchema FOO_COLUMN;
+  private static final HCatFieldSchema BAR_COLUMN;
+  private static final HCatFieldSchema BAZ_COLUMN;
+
+  static {
+    try {
+      FOO_COLUMN = new HCatFieldSchema(FOO, TypeInfoFactory.stringTypeInfo, null);
+      BAR_COLUMN = new HCatFieldSchema(BAR, TypeInfoFactory.stringTypeInfo, null);
+      BAZ_COLUMN = new HCatFieldSchema(BAZ, TypeInfoFactory.stringTypeInfo, null);
+    } catch (HCatException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private final HCatSchema partitionColumns = new HCatSchema(Arrays.asList(BAZ_COLUMN));
+  private final HCatSchema dataColumns = new HCatSchema(Arrays.asList(FOO_COLUMN, BAR_COLUMN));
+
+  @Test(expected = IllegalArgumentException.class)
+  public void duplicateFields() {
+    SchemaUtils.getLowerCaseFieldNames(new Fields(FOO.toUpperCase(), FOO));
+  }
+
+  @Test
+  public void typicalLowerCaseNames() {
+    Set<String> names = SchemaUtils.getLowerCaseFieldNames(new Fields(FOO.toUpperCase()));
+    assertEquals(1, names.size());
+    assertEquals(FOO, names.iterator().next());
+  }
+
+  @Test
+  public void sourceSchemaAll() throws HCatException {
+    Fields fields = new Fields(FOO, BAR, BAZ);
+
+    HCatSchema schema = SchemaUtils.getSourceSchema(partitionColumns, dataColumns, fields);
+
+    assertEquals(3, schema.size());
+    assertEquals(BAZ_COLUMN, schema.get(0));
+    assertEquals(FOO_COLUMN, schema.get(1));
+    assertEquals(BAR_COLUMN, schema.get(2));
+  }
+
+  @Test
+  public void sourceSchemaOmitPartitionColumn() throws HCatException {
+    Fields fields = new Fields(FOO, BAR);
+
+    HCatSchema schema = SchemaUtils.getSourceSchema(partitionColumns, dataColumns, fields);
+
+    assertEquals(2, schema.size());
+    assertEquals(FOO_COLUMN, schema.get(0));
+    assertEquals(BAR_COLUMN, schema.get(1));
+  }
+
+  @Test
+  public void sourceSchemaOmitDataColumn() throws HCatException {
+    Fields fields = new Fields(FOO, BAZ);
+
+    HCatSchema schema = SchemaUtils.getSourceSchema(partitionColumns, dataColumns, fields);
+
+    assertEquals(2, schema.size());
+    assertEquals(BAZ_COLUMN, schema.get(0));
+    assertEquals(FOO_COLUMN, schema.get(1));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void sourceSchemaSpecifyNonExistent() throws HCatException {
+    Fields fields = new Fields(FOO, BAR, BAZ);
+    HCatSchema dataColumns = new HCatSchema(Arrays.asList(FOO_COLUMN));
+
+    SchemaUtils.getSourceSchema(partitionColumns, dataColumns, fields);
+  }
+
+  @Test
+  public void sinkSchemaAll() throws HCatException {
+    Fields fields = new Fields(FOO, BAR, BAZ);
+
+    HCatSchema schema = SchemaUtils.getSinkSchema(partitionColumns, dataColumns, fields);
+
+    assertEquals(3, schema.size());
+    assertEquals(BAZ_COLUMN, schema.get(0));
+    assertEquals(FOO_COLUMN, schema.get(1));
+    assertEquals(BAR_COLUMN, schema.get(2));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void sinkSchemaOmitPartitionColumn() throws HCatException {
+    Fields fields = new Fields(FOO, BAR);
+
+    SchemaUtils.getSinkSchema(partitionColumns, dataColumns, fields);
+  }
+
+  @Test
+  public void sinkSchemaOmitDataColumn() throws HCatException {
+    Fields fields = new Fields(FOO, BAZ);
+
+    HCatSchema schema = SchemaUtils.getSinkSchema(partitionColumns, dataColumns, fields);
+
+    assertEquals(2, schema.size());
+    assertEquals(BAZ_COLUMN, schema.get(0));
+    assertEquals(FOO_COLUMN, schema.get(1));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void sinkSchemaSpecifyNonExistent() throws HCatException {
+    Fields fields = new Fields(FOO, BAR, BAZ);
+    HCatSchema dataColumns = new HCatSchema(Arrays.asList(FOO_COLUMN));
+
+    SchemaUtils.getSinkSchema(partitionColumns, dataColumns, fields);
+  }
+
+}

--- a/src/test/java/cascading/tap/hcatalog/HCatTapTest.java
+++ b/src/test/java/cascading/tap/hcatalog/HCatTapTest.java
@@ -1,0 +1,227 @@
+/*
+* Copyright (c) 2007-2016 Concurrent, Inc. All Rights Reserved.
+*
+* Project and contact information: http://www.cascading.org/
+*
+* This file is part of the Cascading project.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package cascading.tap.hcatalog;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Writer;
+import java.lang.reflect.Type;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocalFileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import cascading.HiveTestCase;
+import cascading.flow.Flow;
+import cascading.pipe.Pipe;
+import cascading.scheme.hadoop.TextDelimited;
+import cascading.scheme.hcatalog.HCatScheme;
+import cascading.tap.hadoop.Hfs;
+import cascading.tuple.Fields;
+
+public class HCatTapTest extends HiveTestCase {
+
+  private static final long serialVersionUID = 1L;
+
+  private static final String DATABASE_NAME = "my_db";
+  private static final String TABLE_NAME = "my_table";
+  private static final String NEW_TABLE_NAME = "my_new_table";
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private File fileFolder;
+  private File tableFolder;
+
+  private Fields dataFields;
+
+  private Fields partitionFields;
+
+  @Before
+  public void init() throws IOException {
+    try {
+      fileFolder = temp.newFolder("file");
+      tableFolder = temp.newFolder("table");
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    runHiveQuery(String.format("CREATE DATABASE %s", DATABASE_NAME));
+    runHiveQuery(String.format(
+        "CREATE TABLE %s.%s (foo STRING, bar INT) PARTITIONED BY (baz STRING) STORED AS ORC LOCATION '%s'",
+        DATABASE_NAME, TABLE_NAME, tableFolder.getCanonicalPath()));
+
+    dataFields = new Fields(new String[] { "foo", "bar" }, new Type[] { String.class, Integer.class });
+    partitionFields = new Fields("baz", String.class);
+  }
+
+  @After
+  public void cleanup() {
+    runHiveQuery(String.format("DROP TABLE IF EXISTS %s.%s", DATABASE_NAME, TABLE_NAME));
+    runHiveQuery(String.format("DROP TABLE IF EXISTS %s.%s", DATABASE_NAME, NEW_TABLE_NAME));
+    runHiveQuery(String.format("DROP DATABASE IF EXISTS %s", DATABASE_NAME));
+  }
+
+  @Test
+  public void resourceExists() throws Exception {
+    HCatTap source = new HCatTap(new HCatScheme(Fields.join(dataFields, partitionFields)), DATABASE_NAME, TABLE_NAME);
+    assertTrue(source.resourceExists(createHiveConf()));
+  }
+
+  @Test
+  public void resourceDoesNotExist() throws Exception {
+    HCatTap source = new HCatTap(new HCatScheme(Fields.join(dataFields, partitionFields)), DATABASE_NAME,
+        NEW_TABLE_NAME);
+    assertFalse(source.resourceExists(createHiveConf()));
+  }
+
+  @Test
+  public void modifiedTime() throws Exception {
+    HCatTap source = new HCatTap(new HCatScheme(Fields.join(dataFields, partitionFields)), DATABASE_NAME, TABLE_NAME);
+    assertTrue(source.getModifiedTime(createHiveConf()) > 0);
+  }
+
+  @Test
+  public void write() throws Exception {
+    try (Writer writer = new FileWriter(new File(fileFolder, "data"))) {
+      writer.write("a\t1\tx\nb\t2\ty\n");
+    }
+
+    Fields fields = dataFields.append(partitionFields);
+    Hfs source = new Hfs(new TextDelimited(fields, "\t"), fileFolder.getCanonicalPath());
+
+    HCatTap sink = new HCatTap(new HCatScheme(Fields.join(dataFields, partitionFields)), DATABASE_NAME, TABLE_NAME);
+
+    Pipe pipe = new Pipe("pipe");
+    Flow flow = getPlatform().getFlowConnector(getProperties()).connect(source, sink, pipe);
+    flow.complete();
+
+    System.out.println(tableFolder.getAbsolutePath());
+
+    List<Partition> listPartitions = createMetaStoreClient().listPartitions(DATABASE_NAME, TABLE_NAME, (short) -1);
+    assertEquals(2, listPartitions.size());
+    assertEquals("x", listPartitions.get(0).getValues().get(0));
+    assertEquals("y", listPartitions.get(1).getValues().get(0));
+
+    List<Object> rows = runHiveQuery(String.format("SELECT * FROM %s.%s ORDER BY bar", DATABASE_NAME, TABLE_NAME));
+    assertEquals(2, rows.size());
+    assertEquals("a\t1\tx", rows.get(0));
+    assertEquals("b\t2\ty", rows.get(1));
+  }
+
+  @Test
+  public void read() throws Exception {
+    runHiveQuery(
+        String.format("INSERT INTO TABLE %s.%s PARTITION (baz='x') VALUES ('a','1')", DATABASE_NAME, TABLE_NAME));
+    runHiveQuery(
+        String.format("INSERT INTO TABLE %s.%s PARTITION (baz='y') VALUES ('b','2')", DATABASE_NAME, TABLE_NAME));
+
+    HCatTap source = new HCatTap(new HCatScheme(Fields.join(dataFields, partitionFields)), DATABASE_NAME, TABLE_NAME);
+
+    Fields fields = dataFields.append(partitionFields);
+    File output = new File(fileFolder, "data");
+    Hfs sink = new Hfs(new TextDelimited(fields, "\t"), output.getCanonicalPath());
+
+    Pipe pipe = new Pipe("pipe");
+    Flow flow = getPlatform().getFlowConnector(getProperties()).connect(source, sink, pipe);
+    flow.complete();
+
+    List<String> lines = readLines(new Path(output.getCanonicalPath()));
+    assertEquals(2, lines.size());
+    assertTrue("Expecting line 'a\t1\tx' but not found", lines.contains("a\t1\tx"));
+    assertTrue("Expecting line 'b\t2\ty' but not found", lines.contains("b\t2\ty"));
+  }
+
+  @Test
+  public void readWithFilter() throws Exception {
+    runHiveQuery(
+        String.format("INSERT INTO TABLE %s.%s PARTITION (baz='x') VALUES ('a','1')", DATABASE_NAME, TABLE_NAME));
+    runHiveQuery(
+        String.format("INSERT INTO TABLE %s.%s PARTITION (baz='y') VALUES ('b','2')", DATABASE_NAME, TABLE_NAME));
+
+    HCatTap source = new HCatTap(new HCatScheme(Fields.join(dataFields, partitionFields)), DATABASE_NAME, TABLE_NAME,
+        "baz='y'");
+
+    Fields fields = dataFields.append(partitionFields);
+    File output = new File(fileFolder, "data");
+    Hfs sink = new Hfs(new TextDelimited(fields, "\t"), output.getCanonicalPath());
+
+    Pipe pipe = new Pipe("pipe");
+    Flow flow = getPlatform().getFlowConnector(getProperties()).connect(source, sink, pipe);
+    flow.complete();
+
+    List<String> lines = readLines(new Path(output.getCanonicalPath()));
+    assertEquals(1, lines.size());
+    assertTrue("Expecting line 'b\t2\ty' but not found", lines.contains("b\t2\ty"));
+  }
+
+  @Test
+  public void columnProjection() throws Exception {
+    runHiveQuery(
+        String.format("INSERT INTO TABLE %s.%s PARTITION (baz='x') VALUES ('a','1')", DATABASE_NAME, TABLE_NAME));
+    runHiveQuery(
+        String.format("INSERT INTO TABLE %s.%s PARTITION (baz='y') VALUES ('b','2')", DATABASE_NAME, TABLE_NAME));
+
+    Fields projectedFields = new Fields("bar", Integer.class);
+    HCatTap source = new HCatTap(new HCatScheme(Fields.join(projectedFields, partitionFields)), DATABASE_NAME,
+        TABLE_NAME, "baz='y'");
+
+    Fields fields = projectedFields.append(partitionFields);
+    File output = new File(fileFolder, "data");
+    Hfs sink = new Hfs(new TextDelimited(fields, "\t"), output.getCanonicalPath());
+
+    Pipe pipe = new Pipe("pipe");
+    Flow flow = getPlatform().getFlowConnector(getProperties()).connect(source, sink, pipe);
+    flow.complete();
+
+    List<String> lines = readLines(new Path(output.getCanonicalPath()));
+    assertEquals(1, lines.size());
+    assertTrue("Expecting line '2\ty' but not found", lines.contains("2\ty"));
+  }
+
+  private static List<String> readLines(Path path) throws Exception {
+    List<String> lines = new LinkedList<>();
+    LocalFileSystem fs = FileSystem.getLocal(new Configuration());
+    FileStatus[] statuses = fs.listStatus(path);
+    for (FileStatus status : statuses) {
+      BufferedReader br = new BufferedReader(new InputStreamReader(fs.open(status.getPath())));
+      String line = null;
+      while ((line = br.readLine()) != null) {
+        lines.add(line);
+      }
+    }
+    return lines;
+  }
+
+}


### PR DESCRIPTION
New Tap and Scheme to source and sink data from/to Hive tables.
These new classes use HCatalog to simplify processing Hive metadata.
Features included:
- Source and sink data from/to both external and managed Hive tables.
- Source and sink data from/to both partitioned and unpartitioned Hive tables.
- Column projection: source taps can select the columns to be ingested by Cascading jobs, any non-required column won't be loaded if the underlying file format of the table supports column projection.
- Partition pruning: source taps can provide a partition predicate to read only the required partition.
- Dynamic partitioning: sink taps will determine in runtime the Hive partition where the data should go. Partition columns must be specify in Cascading Fields.
