### PR TITLE
Make HCatTap compatible with S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,25 @@ future.
 Also note that it is not yet possible to write to transactional tables and that
 the `HiveTap` will prevent any attempt to do so.
 
+Using `HCatTap` to sink data to a Blob Storage service may lead to issues that
+can be hard to deal with due to Blob Storage not being a real file system. If
+you are planning to do so, use it at your own risk.
+
+We encountered various issues when using `HCatTap` to sync tables in S3 but we got
+it working by changing the EMR settings - tested on EMR 4.7.0:
+
+		mapred.output.direct.EmrFileSystem = false
+		mapred.output.direct.NativeS3FileSystem = false
+
+These settings are required in order be able to commit dynamic partitions. This also
+implies that direct commits in EMR will be disabled and the job may take longer during
+the commit phase of tasks and jobs since the underlying `FileSystem` will have to copy
+the files to their final locations and delete the temporary copies. Depending on your use
+case this waiting time and relying on eventually consistent data may or may not be an
+issue.
+
+Note that even though direct commits won't be available, EMR consistent views can still
+be used.
+
 Finally note that Hive relies on the `hadoop` command being present in your
 `PATH` when it executes the queries on the Hadoop cluster.

--- a/src/main/java/cascading/hadoop/mapred/OutputCommitterWrapper.java
+++ b/src/main/java/cascading/hadoop/mapred/OutputCommitterWrapper.java
@@ -29,12 +29,18 @@ public class OutputCommitterWrapper extends org.apache.hadoop.mapred.OutputCommi
   {
 
   private static final String MAPRED_OUTPUT_COMMITTER_CLASS = "mapred.output.committer.class";
+  private static final String WRAPPED_MAPRED_OUTPUT_COMMITTER_CLASS = "wrapped.mapred.output.committer.class";
 
   @SuppressWarnings("rawtypes")
   private final OutputFormatWrapper outputFormat = new OutputFormatWrapper();
 
   protected static void setOutputCommitter( Configuration conf, Class<? extends OutputCommitterWrapper> outputCommitterWrapperClass )
     {
+    String wrappedOutputCommitter = conf.get(MAPRED_OUTPUT_COMMITTER_CLASS);
+    if(wrappedOutputCommitter != null)
+      { 
+      conf.set(WRAPPED_MAPRED_OUTPUT_COMMITTER_CLASS, wrappedOutputCommitter);
+      }
     conf.setClass(MAPRED_OUTPUT_COMMITTER_CLASS, outputCommitterWrapperClass, OutputCommitter.class);
     }
 
@@ -45,7 +51,15 @@ public class OutputCommitterWrapper extends org.apache.hadoop.mapred.OutputCommi
 
   public static void unsetOutputCommitter( Configuration conf )
     {
-    conf.unset( MAPRED_OUTPUT_COMMITTER_CLASS );
+    String wrappedOutputCommitter = conf.get(WRAPPED_MAPRED_OUTPUT_COMMITTER_CLASS);
+    if(wrappedOutputCommitter == null)
+      {
+      conf.unset( MAPRED_OUTPUT_COMMITTER_CLASS );
+      }
+    else
+      {
+      conf.set(MAPRED_OUTPUT_COMMITTER_CLASS, wrappedOutputCommitter);
+      }
     }
 
   private OutputCommitter getOutputCommitter( TaskAttemptContext taskAttemptContext ) throws IOException

--- a/src/main/java/cascading/scheme/hcatalog/PartitionedOutputCommitterWrapper.java
+++ b/src/main/java/cascading/scheme/hcatalog/PartitionedOutputCommitterWrapper.java
@@ -21,14 +21,13 @@ package cascading.scheme.hcatalog;
 import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.mapred.JobContext;
 import org.apache.hadoop.mapred.TaskAttemptContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import cascading.hadoop.mapred.OutputCommitterWrapper;
 
-public class PartitionedOutputCommitterWrapper extends OutputCommitterWrapper
+public class PartitionedOutputCommitterWrapper extends UnpartitionedOutputCommitterWrapper
   {
 
   private static final Logger LOG = LoggerFactory.getLogger( PartitionedOutputCommitterWrapper.class );
@@ -37,14 +36,6 @@ public class PartitionedOutputCommitterWrapper extends OutputCommitterWrapper
     {
     OutputCommitterWrapper.setOutputCommitter( conf, PartitionedOutputCommitterWrapper.class );
    }
-
-  @Override
-  public void setupJob( JobContext jobContext ) throws IOException
-    {
-    unsetOutputCommitter( jobContext.getConfiguration() );
-    super.setupJob( jobContext );
-    setOutputCommitter( jobContext.getConfiguration() );
-    }
 
   @Override
   public void commitTask( TaskAttemptContext taskAttemptContext ) throws IOException
@@ -65,22 +56,6 @@ public class PartitionedOutputCommitterWrapper extends OutputCommitterWrapper
         throw e;
         }
       }
-    }
-
-  @Override
-  public void abortJob(JobContext jobContext, int status) throws IOException
-    {
-    unsetOutputCommitter( jobContext.getConfiguration() );
-    super.abortJob( jobContext, status );
-    setOutputCommitter( jobContext.getConfiguration() );
-    }
-
-  @Override
-  public void commitJob(JobContext jobContext) throws IOException
-    {
-    unsetOutputCommitter( jobContext.getConfiguration() );
-    super.commitJob( jobContext );
-    setOutputCommitter( jobContext.getConfiguration() );
     }
 
   }


### PR DESCRIPTION
- `PartitionedOutputCommitterWrapper` now behaves like `UnpartitionedOutputCommitterWrapper` except for the issue described in the `PartitionedOutputCommitterWrapper#commitTask()`.
- `OutputCommitterWrapper` restores the original `OutputCommitter` - if one was set.
- Two properties need to be set in order to run on EMR+S3:
  mapred.output.direct.EmrFileSystem = false
  mapred.output.direct.NativeS3FileSystem = false
